### PR TITLE
Wire all PlotConfig fields through Project and add per-call overrides

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
           .venv/bin/ruff format --check .
 
       - name: Run mypy
-        run: .venv/bin/mypy
+        run: .venv/bin/mypy --no-incremental
 
       - name: Run pyright
         # continue-on-error: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           .venv/bin/ruff check .
           .venv/bin/ruff format --check .
       - name: Run mypy
-        run: .venv/bin/mypy
+        run: .venv/bin/mypy --no-incremental
       - name: Run pyright
         run: .venv/bin/pyright
       - name: Run deptry

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,12 @@ repos:
     types: [python]
     stages: [pre-commit]
 
-  # - id: pyright-trspecfit
-  #   name: pyright (trspecfit)
-  #   entry: .venv/bin/pyright
-  #   language: system
-  #   pass_filenames: false
-  #   stages: [pre-commit]
+  - id: pyright-trspecfit
+    name: pyright (trspecfit)
+    entry: .venv/bin/pyright
+    language: system
+    pass_filenames: false
+    stages: [pre-commit]
 
   - id: mypy-trspecfit
     name: mypy (trspecfit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,20 +9,28 @@ authors = [
     {name = "Johannes Mahl", email = "johannes.a.mahl@gmail.com"},
 ]
 description = "Fit 2D time- and energy-resolved spectroscopy data"
-keywords = ["fit", "fitting", "spectroscopy", "2D", "multi-dimensional", "time-resolved", "global fit"]
+keywords = [
+  "fit",
+  "fitting",
+  "spectroscopy",
+  "2D",
+  "multi-dimensional",
+  "time-resolved",
+  "global fit",
+  ]
 readme = "README.md"
 license-files = ["LICENSE"]
 requires-python = ">=3.12"
 
 classifiers = [
-       "Development Status :: 3 - Alpha",
-       "Intended Audience :: Science/Research",
-       "Topic :: Scientific/Engineering :: Physics",
-       "License :: OSI Approved :: BSD License",
-       "Programming Language :: Python :: 3",
-       "Programming Language :: Python :: 3.12",
-       "Programming Language :: Python :: 3.13",
-       "Programming Language :: Python :: 3.14",
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Physics",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trspecfit"
-version = "0.7.4"
+version = "0.7.5"
 authors = [
     {name = "Johannes Mahl", email = "johannes.a.mahl@gmail.com"},
 ]

--- a/src/trspecfit/config/plot.py
+++ b/src/trspecfit/config/plot.py
@@ -3,7 +3,7 @@ Configuration of trspecfit plotting functions
 """
 
 import copy as cp
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 # Plot configuration hierarchy:
 #
@@ -180,21 +180,24 @@ class PlotConfig:
             Configuration object with settings from project
         """
 
-        config_dict = {
-            "x_label": project.e_label,
-            "y_label": project.t_label,
-            "z_label": project.z_label,
-            "x_dir": project.x_dir,
-            "x_type": project.x_type,
-            "y_dir": project.y_dir,
-            "y_type": project.y_type,
-            "dpi_plot": project.dpi_plt,
-            "dpi_save": project.dpi_save,
-            "z_colormap": project.z_colormap,
-            "z_colorbar": project.z_colorbar,
-            "z_type": project.z_type,
-            "res_mult": project.res_mult,
+        project_aliases = {
+            "x_label": "e_label",
+            "y_label": "t_label",
+            "dpi_plot": "dpi_plt",
         }
+        limit_fields = {"x_lim", "y_lim", "z_lim"}
+
+        config_dict = {}
+        for field in fields(cls):
+            source_attr = project_aliases.get(field.name, field.name)
+            if not hasattr(project, source_attr):
+                continue
+
+            value = cp.deepcopy(getattr(project, source_attr))
+            if field.name in limit_fields and value is not None:
+                value = tuple(value)
+
+            config_dict[field.name] = value
 
         # Apply any overrides
         config_dict.update(overrides)

--- a/src/trspecfit/mcp.py
+++ b/src/trspecfit/mcp.py
@@ -879,6 +879,8 @@ class Model:
         y_lim: tuple[float, float] | None = None,
         save_img: int = 0,
         save_path: str = "",
+        config: PlotConfig | None = None,
+        **plot_kwargs,
     ) -> None:
         """
         Plot 1D model spectrum (energy or time).
@@ -907,10 +909,16 @@ class Model:
             - -1: Save only (no display)
         save_path : str, default=''
             Path for saving figure (if save_img != 0)
+        config : PlotConfig, optional
+            Override the model's inherited plot configuration for this call.
+            If None, uses the model's own plot_config.
+        **plot_kwargs : dict
+            Per-call overrides for any PlotConfig field (e.g. ``colors``,
+            ``ticksize``, ``legend``). Applied on top of *config*.
         """
 
         # Get model config for plotting
-        config = self.plot_config
+        config = config or self.plot_config
 
         # Model calling this method is a ...
         # ... time-resolved model (mcp.Dynamics)
@@ -939,24 +947,19 @@ class Model:
         plot_data = (
             [cast("np.ndarray", self.value_1d)] if plot_sum else self.component_spectra
         )
-        uplt.plot_1d(
-            data=plot_data,
-            x=x,
-            config=config,
-            title=f'Model "{self.name}" {info}',
-            x_label=x_label,
-            y_label=config.z_label,
-            x_dir=x_dir,
-            x_lim=x_lim,
-            y_lim=y_lim,
-            legend=[
-                "sum",
-            ]
-            if plot_sum
-            else [c.name for c in self.components],
-            save_img=save_img,
-            save_path=save_path,
-        )
+        _call_kwargs: dict = {
+            "title": f'Model "{self.name}" {info}',
+            "x_label": x_label,
+            "y_label": config.z_label,
+            "x_dir": x_dir,
+            "x_lim": x_lim,
+            "y_lim": y_lim,
+            "legend": ["sum"] if plot_sum else [c.name for c in self.components],
+            "save_img": save_img,
+            "save_path": save_path,
+        }
+        _call_kwargs.update(plot_kwargs)
+        uplt.plot_1d(data=plot_data, x=x, config=config, **_call_kwargs)
 
     #
     def plot_2d(
@@ -966,6 +969,8 @@ class Model:
         x_lim: tuple[float, float] | None = None,
         y_lim: tuple[float, float] | None = None,
         z_lim: tuple[float, float] | None = None,
+        config: PlotConfig | None = None,
+        **plot_kwargs,
     ) -> None:
         """
         Plot 2D time-and-energy spectrum as heatmap.
@@ -989,6 +994,12 @@ class Model:
             Time axis display range (min, max)
         z_lim : tuple of float, optional
             Color scale limits (min, max)
+        config : PlotConfig, optional
+            Override the model's inherited plot configuration for this call.
+            If None, uses the model's own plot_config.
+        **plot_kwargs : dict
+            Per-call overrides for any PlotConfig field (e.g. ``z_colormap``,
+            ``ticksize``). Applied on top of *config*.
         """
 
         if self.value_2d is None:
@@ -996,17 +1007,21 @@ class Model:
         if self.value_2d is None or self.energy is None or self.time is None:
             raise ValueError("Model value_2d, energy, and time required for plot_2d")
         # Plot using the utility plot_2d
+        _call_kwargs: dict = {
+            "title": f'model "{self.name}"',
+            "x_lim": x_lim,
+            "y_lim": y_lim,
+            "z_lim": z_lim,
+            "save_img": save_img,
+            "save_path": save_path,
+        }
+        _call_kwargs.update(plot_kwargs)
         uplt.plot_2d(
             data=self.value_2d,
             x=self.energy,
             y=self.time,
-            config=self.plot_config,
-            title=f'model "{self.name}"',
-            x_lim=x_lim,
-            y_lim=y_lim,
-            z_lim=z_lim,
-            save_img=save_img,
-            save_path=save_path,
+            config=config or self.plot_config,
+            **_call_kwargs,
         )
 
 
@@ -1641,6 +1656,8 @@ class Component:
         plot_every: int = 1,
         plot_max: int | None = None,
         save_img: int = 0,
+        config: PlotConfig | None = None,
+        plot_kwargs: dict | None = None,
         **kwargs,
     ) -> None:
         """
@@ -1666,6 +1683,12 @@ class Component:
             First plot_max traces are shown (spaced according to plot_every).
         save_img : int, default=0
             0: display, 1: save+display, -1: save only, -2: close (no display/save)
+        config : PlotConfig, optional
+            Override the inherited plot configuration for this call.
+            If None, falls back to the parent model's plot_config.
+        plot_kwargs : dict, optional
+            Per-call overrides for any PlotConfig field (e.g. ``colors``,
+            ``ticksize``). Applied on top of *config*.
         **kwargs : dict
             Additional arguments passed to component function.
             Background components require ``spectrum`` to be provided.
@@ -1684,8 +1707,7 @@ class Component:
             )
 
         # get x axis, label, and plot config
-        config = None
-        if self.parent_model is not None:
+        if config is None and self.parent_model is not None:
             config = self.parent_model.plot_config
 
         if self.package == fcts_energy:
@@ -1743,17 +1765,16 @@ class Component:
             x_dir = config.x_dir
 
         #
-        uplt.plot_1d(
-            data=plot_data,
-            config=config,
-            title=f"function: {self.fct_str} from {self.package_name}",
-            x=x_axis,
-            x_label=x_name,
-            x_dir=x_dir,
-            y_label="Amplitude",
-            legend=legend,
-            save_img=save_img,
-        )
+        _call_kwargs: dict = {
+            "title": f"function: {self.fct_str} from {self.package_name}",
+            "x_label": x_name,
+            "x_dir": x_dir,
+            "y_label": "Amplitude",
+            "legend": legend,
+            "save_img": save_img,
+        }
+        _call_kwargs.update(plot_kwargs or {})
+        uplt.plot_1d(data=plot_data, config=config, x=x_axis, **_call_kwargs)
 
 
 #

--- a/src/trspecfit/simulator.py
+++ b/src/trspecfit/simulator.py
@@ -63,6 +63,7 @@ import h5py
 import matplotlib.pyplot as plt
 import numpy as np
 
+from trspecfit.config.plot import PlotConfig
 from trspecfit.mcp import Model
 from trspecfit.utils import plot as uplt
 from trspecfit.utils.hdf5 import require_group
@@ -1193,6 +1194,8 @@ class Simulator:
         snr_scale: str = "linear",
         *,
         save_img: int = 0,
+        config: PlotConfig | None = None,
+        **plot_kwargs,
     ) -> None:
         """
         Plot comparison of clean vs noisy data.
@@ -1215,6 +1218,12 @@ class Simulator:
             - 'dB': Show in decibels (e.g., "SNR: 14.0 dB")
         save_img : int, default=0
             0: display, 1: save+display, -1: save only, -2: close (no display/save)
+        config : PlotConfig, optional
+            Override the model's inherited plot configuration for this call.
+            If None, uses the model's own plot_config.
+        **plot_kwargs : dict
+            Per-call overrides for any PlotConfig field (e.g. ``z_colormap``,
+            ``ticksize``). Applied on top of *config*.
 
         Examples
         --------
@@ -1304,19 +1313,23 @@ class Simulator:
                 raise RuntimeError("Simulation data not available for plotting")
 
             # Get config from model
-            config = self.model.plot_config
+            resolved_config = config or self.model.plot_config
 
             # Plot with noisy data as scatter
+            _call_kwargs: dict = {
+                "title": plt_title,
+                "legend": ["Clean", "Noisy", "Noise"],
+                "linestyles": ["-", "", "-"],  # Empty string = no line for noisy data
+                "markers": [None, "o", None],  # Scatter points for noisy data
+                "markersizes": [6, 3, 6],  # Smaller markers for noisy data
+                "save_img": save_img,
+            }
+            _call_kwargs.update(plot_kwargs)
             uplt.plot_1d(
                 data=[self.data_clean, self.data_noisy, self.noise],
                 x=self.model.energy,
-                config=config,
-                title=plt_title,
-                legend=["Clean", "Noisy", "Noise"],
-                linestyles=["-", "", "-"],  # Empty string = no line for noisy data
-                markers=[None, "o", None],  # Scatter points for noisy data
-                markersizes=[6, 3, 6],  # Smaller markers for noisy data
-                save_img=save_img,
+                config=resolved_config,
+                **_call_kwargs,
             )
 
         elif dim == 2:
@@ -1326,7 +1339,9 @@ class Simulator:
                 raise RuntimeError("Simulation data not available for plotting")
 
             # Get config from model
-            config = self.model.plot_config
+            resolved_config = config or self.model.plot_config
+            if plot_kwargs:
+                resolved_config = resolved_config.copy(**plot_kwargs)
 
             # Create 3-panel plot
             _fig, axes = plt.subplots(1, 3, figsize=(15, 4))
@@ -1342,21 +1357,21 @@ class Simulator:
                     self.model.time,
                     data,
                     shading="nearest",
-                    cmap=config.z_colormap,
+                    cmap=resolved_config.z_colormap,
                 )
                 ax.set_title(title)
-                ax.set_xlabel(config.x_label)
-                ax.set_ylabel(config.y_label)
-                if config.ticksize is not None:
-                    ax.tick_params(labelsize=config.ticksize)
+                ax.set_xlabel(resolved_config.x_label)
+                ax.set_ylabel(resolved_config.y_label)
+                if resolved_config.ticksize is not None:
+                    ax.tick_params(labelsize=resolved_config.ticksize)
                 uplt._apply_axis_settings(
                     ax,
-                    x_type=config.x_type,
-                    x_dir=config.x_dir,
-                    y_type=config.y_type,
-                    y_dir=config.y_dir,
-                    x_lim=config.x_lim,
-                    y_lim=config.y_lim,
+                    x_type=resolved_config.x_type,
+                    x_dir=resolved_config.x_dir,
+                    y_type=resolved_config.y_type,
+                    y_dir=resolved_config.y_dir,
+                    x_lim=resolved_config.x_lim,
+                    y_lim=resolved_config.y_lim,
                 )
                 plt.colorbar(im, ax=ax)
 
@@ -1364,7 +1379,7 @@ class Simulator:
             uplt._finalize_plot(
                 save_img=save_img,
                 save_path="",
-                dpi_save=config.dpi_save,
+                dpi_save=resolved_config.dpi_save,
             )
 
     #

--- a/src/trspecfit/trspecfit.py
+++ b/src/trspecfit/trspecfit.py
@@ -398,7 +398,7 @@ class Project:
             # Update attributes from config
             for key, value in config.items():
                 normalized_key = key.replace("-", "_")
-                project_key = {
+                project_key: str = {
                     "x_label": "e_label",
                     "y_label": "t_label",
                     "dpi_plot": "dpi_plt",

--- a/src/trspecfit/trspecfit.py
+++ b/src/trspecfit/trspecfit.py
@@ -398,11 +398,12 @@ class Project:
             # Update attributes from config
             for key, value in config.items():
                 normalized_key = key.replace("-", "_")
-                project_key: str = {
+                _key_map = {
                     "x_label": "e_label",
                     "y_label": "t_label",
                     "dpi_plot": "dpi_plt",
-                }.get(normalized_key, normalized_key)
+                }
+                project_key = _key_map.get(normalized_key) or normalized_key
 
                 if hasattr(self, project_key):
                     setattr(self, project_key, value)

--- a/src/trspecfit/trspecfit.py
+++ b/src/trspecfit/trspecfit.py
@@ -200,6 +200,24 @@ class Project:
         self.dpi_plt = 100
         self.dpi_save = 300
         self.res_mult = 5
+        self.title = ""
+        self.x_lim = None
+        self.y_lim = None
+        self.data_slice = None
+        self.z_lim = None
+        self.colors = None
+        self.linestyles = None
+        self.linewidths = None
+        self.markers = None
+        self.markersizes = None
+        self.alphas = None
+        self.legend = None
+        self.waterfall = 0
+        self.vlines = None
+        self.hlines = None
+        self.ticksize = None
+        self.y_norm = 0
+        self.y_scale = None
         # File I/O settings
         self.ext = ".dat"
         self.fmt = "%.6e"
@@ -379,8 +397,15 @@ class Project:
 
             # Update attributes from config
             for key, value in config.items():
-                if hasattr(self, key):
-                    setattr(self, key, value)
+                normalized_key = key.replace("-", "_")
+                project_key = {
+                    "x_label": "e_label",
+                    "y_label": "t_label",
+                    "dpi_plot": "dpi_plt",
+                }.get(normalized_key, normalized_key)
+
+                if hasattr(self, project_key):
+                    setattr(self, project_key, value)
                 else:
                     if self.show_output >= 1:
                         print(f"Warning: Unknown config key '{key}' ignored")

--- a/src/trspecfit/utils/plot.py
+++ b/src/trspecfit/utils/plot.py
@@ -794,13 +794,17 @@ def _apply_axis_settings(
         ax.set_xscale("log")
     if x_lim is not None:
         ax.set_xlim(x_lim[0], x_lim[1])
-    if x_dir == "rev":
+    if x_dir == "rev" and not ax.xaxis_inverted():
+        ax.invert_xaxis()
+    elif x_dir != "rev" and ax.xaxis_inverted():
         ax.invert_xaxis()
     if y_type == "log":
         ax.set_yscale("log")
     if y_lim is not None:
         ax.set_ylim(y_lim[0], y_lim[1])
-    if y_dir == "rev":
+    if y_dir == "rev" and not ax.yaxis_inverted():
+        ax.invert_yaxis()
+    elif y_dir != "rev" and ax.yaxis_inverted():
         ax.invert_yaxis()
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -538,6 +538,8 @@ class TestPlotConfigFromYAML:
         "z_label: 'Counts'\n"
         "x_dir: 'rev'\n"
         "z_colormap: 'RdBu'\n"
+        "x_lim: [63.0, -2.6]\n"
+        "y_lim: [-0.5, 5.0]\n"
     )
 
     EXPECTED = {
@@ -546,6 +548,8 @@ class TestPlotConfigFromYAML:
         "z_label": "Counts",
         "x_dir": "rev",
         "z_colormap": "RdBu",
+        "x_lim": (63.0, -2.6),
+        "y_lim": (-0.5, 5.0),
     }
 
     #
@@ -574,6 +578,26 @@ class TestPlotConfigFromYAML:
             assert project.z_label == "Counts"
             assert project.x_dir == "rev"
             assert project.z_colormap == "RdBu"
+            assert project.x_lim == [63.0, -2.6]
+            assert project.y_lim == [-0.5, 5.0]
+
+    #
+    def test_project_accepts_hyphenated_limit_keys(self, capsys):
+        """Hyphenated PlotConfig keys in project.yaml should map cleanly."""
+
+        yaml_content = "x-lim: [63.0, -2.6]\ny-lim: [-0.5, 5.0]\n"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "project.yaml").write_text(yaml_content)
+            project = Project(path=tmpdir, name="test")
+
+            captured = capsys.readouterr()
+            assert "Unknown config key 'x-lim'" not in captured.out
+            assert "Unknown config key 'y-lim'" not in captured.out
+            assert project.x_lim == [63.0, -2.6]
+            assert project.y_lim == [-0.5, 5.0]
+            assert PlotConfig.from_project(project).x_lim == (63.0, -2.6)
+            assert PlotConfig.from_project(project).y_lim == (-0.5, 5.0)
 
     #
     def test_file_plot_config_inherits_yaml(self):
@@ -704,6 +728,20 @@ class TestPlotConfigPropagation:
         plt.close("all")
 
     #
+    def test_component_plot_keeps_reversed_limit_and_direction(self):
+        """Component.plot() should not double-flip when x_lim is already reversed."""
+
+        file = self._make_file_with_model(x_dir="rev")
+        file.plot_config = file.plot_config.copy(x_lim=(63.0, -2.6))
+        assert file.model_active is not None  # type guard
+        component = file.model_active.components[0]
+
+        component.plot()
+        ax = plt.gca()
+        assert ax.xaxis_inverted(), "x-axis should remain inverted with reversed x_lim"
+        plt.close("all")
+
+    #
     def test_component_plot_default_dir(self):
         """Component.plot() should not invert x-axis when config.x_dir='def'."""
 
@@ -779,6 +817,195 @@ class TestEdgeCases:
         config = PlotConfig()
 
         plot_1d([y], x=x, config=config, save_img=-2)
+        plt.close("all")
+
+
+#
+#
+class TestHighLevelPlotOverrides:
+    """Per-call config= and plot_kwargs overrides on high-level plot methods."""
+
+    #
+    def _make_file_with_model(self):
+        """Return a File with a loaded energy model, default x_dir='def'."""
+
+        project = Project(path="tests")
+        project.e_label = "Binding Energy (eV)"
+        project.x_dir = "def"
+
+        file = File(parent_project=project)
+        file.energy = np.linspace(80, 90, 201)
+        file.time = np.linspace(-10, 100, 111)
+        file.data = np.random.default_rng(0).normal(
+            size=(len(file.time), len(file.energy))
+        )
+        file.dim = 2
+        file.load_model(
+            model_yaml="models/file_energy.yaml",
+            model_info="single_glp",
+        )
+        return file
+
+    #
+    def test_model_plot_1d_config_override(self):
+        """Model.plot_1d(config=...) uses the supplied config, not the inherited one."""
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+
+        override = PlotConfig(x_dir="rev", x_label="Override (eV)")
+        model.plot_1d(config=override, save_img=0)
+        ax = plt.gca()
+        assert ax.get_xlabel() == "Override (eV)"
+        assert ax.xaxis_inverted()
+        plt.close("all")
+
+    #
+    def test_model_plot_1d_plot_kwargs_override(self):
+        """Model.plot_1d(**plot_kwargs) overrides individual fields."""
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+
+        model.plot_1d(x_dir="rev", save_img=0)
+        ax = plt.gca()
+        assert ax.xaxis_inverted()
+        plt.close("all")
+
+    #
+    def test_model_plot_2d_config_override(self):
+        """Model.plot_2d(config=...) uses the supplied config."""
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+
+        override = PlotConfig(x_dir="rev")
+        model.plot_2d(config=override, save_img=0)
+        ax = plt.gcf().axes[0]
+        assert ax.xaxis_inverted()
+        plt.close("all")
+
+    #
+    def test_model_plot_2d_plot_kwargs_override(self):
+        """Model.plot_2d(**plot_kwargs) overrides individual fields."""
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+
+        model.plot_2d(x_dir="rev", save_img=0)
+        ax = plt.gcf().axes[0]
+        assert ax.xaxis_inverted()
+        plt.close("all")
+
+    #
+    def test_component_plot_config_override(self):
+        """Component.plot(config=...) uses the supplied config."""
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+        component = model.components[0]
+
+        override = PlotConfig(x_dir="rev", x_label="Custom (eV)")
+        component.plot(config=override, save_img=0)
+        ax = plt.gca()
+        assert ax.get_xlabel() == "Custom (eV)"
+        assert ax.xaxis_inverted()
+        plt.close("all")
+
+    #
+    def test_component_plot_plot_kwargs_override(self):
+        """Component.plot(plot_kwargs=...) overrides individual fields."""
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+        component = model.components[0]
+
+        component.plot(plot_kwargs={"x_dir": "rev"}, save_img=0)
+        ax = plt.gca()
+        assert ax.xaxis_inverted()
+        plt.close("all")
+
+    #
+    def test_simulator_plot_comparison_config_override_dim1(self):
+        """Simulator.plot_comparison(dim=1, config=...) uses the supplied config."""
+
+        from trspecfit import Simulator
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+        sim = Simulator(model, noise_level=0.05)
+        sim.simulate_1d()
+
+        override = PlotConfig(x_dir="rev")
+        sim.plot_comparison(dim=1, config=override, save_img=0)
+        ax = plt.gca()
+        assert ax.xaxis_inverted()
+        plt.close("all")
+
+    #
+    def test_simulator_plot_comparison_plot_kwargs_override_dim1(self):
+        """Simulator.plot_comparison(dim=1, **plot_kwargs) overrides PlotConfig."""
+
+        from trspecfit import Simulator
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+        sim = Simulator(model, noise_level=0.05)
+        sim.simulate_1d()
+
+        sim.plot_comparison(dim=1, x_dir="rev", save_img=0)
+        ax = plt.gca()
+        assert ax.xaxis_inverted()
+        plt.close("all")
+
+    #
+    def test_simulator_plot_comparison_config_override_dim2(self):
+        """Simulator.plot_comparison(dim=2, config=...) applies config to all panels."""
+
+        from trspecfit import Simulator
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+        sim = Simulator(model, noise_level=0.05)
+        sim.simulate_2d()
+
+        override = PlotConfig(x_dir="rev", x_label="Override (eV)")
+        sim.plot_comparison(dim=2, config=override, save_img=0)
+        fig = plt.gcf()
+        main_axes = [ax for ax in fig.axes if ax.get_xlabel() != ""]
+        assert any(ax.get_xlabel() == "Override (eV)" for ax in main_axes)
+        assert all(
+            ax.xaxis_inverted()
+            for ax in main_axes
+            if ax.get_xlabel() == "Override (eV)"
+        )
+        plt.close("all")
+
+    #
+    def test_simulator_plot_comparison_plot_kwargs_override_dim2(self):
+        """Simulator.plot_comparison(dim=2, **plot_kwargs) overrides config fields."""
+
+        from trspecfit import Simulator
+
+        file = self._make_file_with_model()
+        model = file.model_active
+        assert model is not None  # type guard
+        sim = Simulator(model, noise_level=0.05)
+        sim.simulate_2d()
+
+        sim.plot_comparison(dim=2, x_dir="rev", save_img=0)
+        fig = plt.gcf()
+        main_axes = [ax for ax in fig.axes if ax.get_xlabel() != ""]
+        assert all(ax.xaxis_inverted() for ax in main_axes)
         plt.close("all")
 
 


### PR DESCRIPTION
Project now exposes every PlotConfig field as an attribute (limits, colors, linestyles, waterfall, etc.), so project.yaml can fully configure plotting without code changes.

PlotConfig.from_project() is rewritten to iterate over dataclass fields rather than enumerating them manually, so new fields are picked up automatically.

Model.plot_1d, Model.plot_2d, Component.plot, and
Simulator.plot_comparison each gain a config= argument (replace the inherited config for one call) and a way to pass per-call overrides (**plot_kwargs / plot_kwargs=) that are merged on top of the config.

Adds TestPlotConfigFromYAML and TestHighLevelPlotOverrides test classes covering YAML-to-config propagation and the new override paths.